### PR TITLE
Include principal token value in pool TVL calculation

### DIFF
--- a/projects/illuminate-fi/index.js
+++ b/projects/illuminate-fi/index.js
@@ -3,7 +3,7 @@ const { sumTokens2 } = require('../helper/unwrapLPs')
 
 async function tvl(_, _b, _cb, { api, }) {
   const market = '0xcd1d02fda51cd24123e857ce94e4356d5c073b3f'
-  const logs = await getLogs({
+  const createMarketLogs = await getLogs({
     api,
     target: market,
     topics: ['0xb02abdc1b2e46d6aa310c4e8bcab63f9ec42f82c0bba87fefe442f2b21d60871'],
@@ -11,8 +11,16 @@ async function tvl(_, _b, _cb, { api, }) {
     onlyArgs: true,
     fromBlock: 16973041,
   })
+  const setPoolLogs = await getLogs({
+    api,
+    target: market,
+    topics: ['0x55209e3c7f85dc20f4a87c5797c01f02e573346bef47c8b034f89ace44a985a4'],
+    eventAbi: 'event SetPool (address indexed underlying, uint256 indexed maturity, address indexed pool)',
+    onlyArgs: true,
+    fromBlock: 16973041,
+  });
 
-  const calls = logs.map(i => ( { params: [i.underlying, +i.maturity]}))
+  const calls = createMarketLogs.map(i => ( { params: [i.underlying, +i.maturity]}))
   const pools = await api.multiCall({ abi: 'function pools(address, uint256) view returns (address)', calls, target: market })
   const baseTokens = await api.multiCall({ abi: 'address:baseToken', calls: pools })
   const sharesTokens = await api.multiCall({ abi: 'address:sharesToken', calls: pools })
@@ -20,11 +28,18 @@ async function tvl(_, _b, _cb, { api, }) {
 
   // Add the value of the principal tokens in the pool
   const principalTokens = await api.multiCall({ abi: 'address:fyToken', calls: pools })
-  const principalTokenPrices = await api.multiCall({ abi: 'function sellFYTokenPreview(uint256) view returns (uint256)', calls: pools })
   const principalTokenDecimals = await api.multiCall({ abi: 'uint256:decimals', calls: pools })
-  principalTokens.forEach((v, i) => ownerTokens.push([(v * principalTokenPrices[i]) / 10**(principalTokenDecimals[i]), pools[i]]))
+  const oneCalls = createMarketLogs.map(i => ( { params: 10**principalTokenDecimals[i] } ) )
+  const principalTokenPrices = await api.multiCall({ abi: 'function sellFYTokenPreview(uint256) view returns (uint256)', oneCalls, calls: pools })
+  
+  const balanceOfCalls = setPoolLogs.map(i => ( { params: [i.pool]}))
+  const principalTokenBalances = await api.multiCall( { abi: 'function balanceOf(address) view returns (uint256)', balanceOfCalls, calls: principalTokens })
+  
+  // sum up the balance held by the pools weighted by their current price
+  var principalTokenTvl = 0 
+  principalTokenBalances.forEach((v, i) => principalTokenTvl += v * principalTokenPrices / 10**principalTokenDecimals[i])
 
-  return sumTokens2({ api, ownerTokens, })
+  return sumTokens2({ api, ownerTokens, }) + principalTokenTvl;
 }
 
 module.exports = {


### PR DESCRIPTION
In this PR, I updated the adapter to include the value of `fyToken`s in the pool. To do so, I query the value of a single `fyToken` and multiply it by the total supply of principal tokens held in a given pool. This should give us a rough approximation of how much value is being used in pools to provide liquidity. 